### PR TITLE
Updated AUTO_TRIGGER_PIN value definitions

### DIFF
--- a/ParameterMetaDataBackup.xml
+++ b/ParameterMetaDataBackup.xml
@@ -8554,7 +8554,7 @@
     <AUTO_TRIGGER_PIN>
       <DisplayName>Auto mode trigger pin</DisplayName>
       <Description>pin number to use to enable the throttle in auto mode. If set to -1 then don't use a trigger, otherwise this is a pin number which if held low in auto mode will enable the motor to run. If the switch is released while in AUTO then the motor will stop again. This can be used in combination with INITIAL_MODE to give a 'press button to start' rover with no receiver.</Description>
-      <Values>-1:Disabled,0-8:TiggerPin</Values>
+      <Values>-1:Disabled, 0-8:APM TriggerPin, 50-55: Pixhawk TriggerPin</Values>
       <User>standard</User>
     </AUTO_TRIGGER_PIN>
     <AUTO_KICKSTART>


### PR DESCRIPTION
Mission Planner and parameter.h definitions seem to be outdated. A bit confusing because when its readed, you think you need to define it between 0-8 (APM boards) instead of 50-55 (PX4-Pixhawk boards).