### PR TITLE
Uploader refactor: broke up enum values into two enums

### DIFF
--- a/ExtLibs/px4uploader/Uploader.cs
+++ b/ExtLibs/px4uploader/Uploader.cs
@@ -58,18 +58,20 @@ namespace px4uploader
             GET_SN = 0x2b,    // read a word from UDID area ( Serial)  at the given address 
             GET_CHIP = 0x2c, // read chip version (MCU IDCODE)
             REBOOT = 0x30,
-
-            INFO_BL_REV = 1,//	# bootloader protocol revision
-            BL_REV_MIN = 2,//	# minimum supported bootloader protocol 
-            BL_REV_MAX = 4,//	# maximum supported bootloader protocol 
-            INFO_BOARD_ID = 2,//	# board type
-            INFO_BOARD_REV = 3,//	# board revision
-            INFO_FLASH_SIZE = 4,//	# max firmware size in bytes
-
-            PROG_MULTI_MAX = 60,//		# protocol max is 255, must be multiple of 4
-            READ_MULTI_MAX = 60,//		# protocol max is 255, something overflows with >= 64
-
         }
+
+        public enum Info {
+            BL_REV = 1,//	# bootloader protocol revision
+            BOARD_ID = 2,//	# board type
+            BOARD_REV = 3,//	# board revision
+            FLASH_SIZE = 4,//	# max firmware size in bytes
+        }
+
+        public const byte BL_REV_MIN = 2;//	# minimum supported bootloader protocol 
+        public const byte BL_REV_MAX = 4;//	# maximum supported bootloader protocol 
+        public const byte PROG_MULTI_MAX = 60;//		# protocol max is 255, must be multiple of 4
+        public const byte READ_MULTI_MAX = 60;//		# protocol max is 255, something overflows with >= 64
+
 
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
         struct otp
@@ -425,7 +427,7 @@ namespace px4uploader
             return true;
         }
 
-        public int __getInfo(Code param)
+        public int __getInfo(Info param)
         {
             __send(new byte[] { (byte)Code.GET_DEVICE, (byte)param, (byte)Code.EOC });
             int info = __recv_int();
@@ -530,7 +532,7 @@ namespace px4uploader
         public void __program(Firmware fw)
         {
             byte[] code = fw.imagebyte;
-            List<byte[]> groups = self.__split_len(code, (byte)Code.PROG_MULTI_MAX);
+            List<byte[]> groups = self.__split_len(code, PROG_MULTI_MAX);
             Console.WriteLine("Programing packet total: "+groups.Count);
             int a = 1;
             foreach (Byte[] bytes in groups)
@@ -551,7 +553,7 @@ namespace px4uploader
 				, (byte)Code.EOC});
             self.__getSync();
             byte[] code = fw.imagebyte;
-            List<byte[]> groups = self.__split_len(code, (byte)Code.READ_MULTI_MAX);
+            List<byte[]> groups = self.__split_len(code, READ_MULTI_MAX);
             int a = 1;
             foreach (byte[] bytes in groups)
             {
@@ -623,17 +625,17 @@ namespace px4uploader
             //Console.WriteLine("1 "+DateTime.Now.Millisecond);
 
             //get the bootloader protocol ID first
-            self.bl_rev = self.__getInfo(Code.INFO_BL_REV);
+            self.bl_rev = self.__getInfo(Info.BL_REV);
 
            // Console.WriteLine("2 " + DateTime.Now.Millisecond);
-            if ((bl_rev < (int)Code.BL_REV_MIN) || (bl_rev > (int)Code.BL_REV_MAX))
+            if ((bl_rev < (int)BL_REV_MIN) || (bl_rev > (int)BL_REV_MAX))
             {
                 throw new Exception("Bootloader protocol mismatch");
             }
 
-            self.board_type = self.__getInfo(Code.INFO_BOARD_ID);
-            self.board_rev = self.__getInfo(Code.INFO_BOARD_REV);
-            self.fw_maxsize = self.__getInfo(Code.INFO_FLASH_SIZE);
+            self.board_type = self.__getInfo(Info.BOARD_ID);
+            self.board_rev = self.__getInfo(Info.BOARD_REV);
+            self.fw_maxsize = self.__getInfo(Info.FLASH_SIZE);
         }
 
         public void upload(Firmware fw)


### PR DESCRIPTION
Uploader: broke up enum values into two enums (created ne Info enum) and moved others to consts due to improper enum use in "Code".

non-function code change