### PR TITLE
Fix Rel vs AMSL Altitude Logic

### DIFF
--- a/georefimage.cs
+++ b/georefimage.cs
@@ -1621,11 +1621,11 @@ namespace MissionPlanner
             {
                 if (useAMSLAlt)
                 {
-                    WriteCoordinatesToImage(picInfo.Path, picInfo.Lat, picInfo.Lon, double.Parse(txt_basealt.Text) + picInfo.RelAlt);
+                    WriteCoordinatesToImage(picInfo.Path, picInfo.Lat, picInfo.Lon, double.Parse(txt_basealt.Text) + picInfo.AltAMSL);
                 } 
                 else
                 {
-                    WriteCoordinatesToImage(picInfo.Path, picInfo.Lat, picInfo.Lon, picInfo.AltAMSL);
+                    WriteCoordinatesToImage(picInfo.Path, picInfo.Lat, picInfo.Lon, picInfo.RelAlt);
                 }
             }
 


### PR DESCRIPTION
The use of relative altitude vs AMSL was reversed in relation to the
check box. If the “Use AMSL” check box is checked it should write AMSL
to the pictures.