### PR TITLE
Make MissionPlanner waypoint lists compatible with QGroundControl

### DIFF
--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -1509,7 +1509,7 @@ namespace MissionPlanner.GCSViews
         {
             using (SaveFileDialog fd = new SaveFileDialog())
             {
-                fd.Filter = "Ardupilot Mission (*.txt)|*.*";
+                fd.Filter = "Ardupilot Mission (*.txt)|(*.waypoints)|*.*";
                 fd.DefaultExt = ".txt";
                 fd.FileName = wpfilename;
                 DialogResult result = fd.ShowDialog();
@@ -1519,7 +1519,7 @@ namespace MissionPlanner.GCSViews
                     try
                     {
                         StreamWriter sw = new StreamWriter(file);
-                        sw.WriteLine("QGC WPL 110");
+                        sw.WriteLine("QGC WPL 120");
                         try
                         {
                             sw.WriteLine("0\t1\t0\t16\t0\t0\t0\t0\t" + double.Parse(TXT_homelat.Text).ToString("0.000000", new CultureInfo("en-US")) + "\t" + double.Parse(TXT_homelng.Text).ToString("0.000000", new CultureInfo("en-US")) + "\t" + double.Parse(TXT_homealt.Text).ToString("0.000000", new CultureInfo("en-US")) + "\t1");

--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -1509,7 +1509,7 @@ namespace MissionPlanner.GCSViews
         {
             using (SaveFileDialog fd = new SaveFileDialog())
             {
-                fd.Filter = "Ardupilot Mission (*.txt)|(*.waypoints)|*.*";
+                fd.Filter = "Ardupilot Mission (*.waypoints)|(*.txt)|*.*";
                 fd.DefaultExt = ".txt";
                 fd.FileName = wpfilename;
                 DialogResult result = fd.ShowDialog();

--- a/Log/MavlinkLog.cs
+++ b/Log/MavlinkLog.cs
@@ -1534,7 +1534,7 @@ namespace MissionPlanner.Log
 
 
 
-                                StreamWriter sw = new StreamWriter(Path.GetDirectoryName(logfile) + Path.DirectorySeparatorChar + Path.GetFileNameWithoutExtension(logfile) + "-" + wplists + ".txt");
+                                StreamWriter sw = new StreamWriter(Path.GetDirectoryName(logfile) + Path.DirectorySeparatorChar + Path.GetFileNameWithoutExtension(logfile) + "-" + wplists + ".waypoints");
 
                                 sw.WriteLine("QGC WPL 120");
                                 try

--- a/Log/MavlinkLog.cs
+++ b/Log/MavlinkLog.cs
@@ -1536,7 +1536,7 @@ namespace MissionPlanner.Log
 
                                 StreamWriter sw = new StreamWriter(Path.GetDirectoryName(logfile) + Path.DirectorySeparatorChar + Path.GetFileNameWithoutExtension(logfile) + "-" + wplists + ".txt");
 
-                                sw.WriteLine("QGC WPL 110");
+                                sw.WriteLine("QGC WPL 120");
                                 try
                                 {
                                     //get mission count info 


### PR DESCRIPTION
First commit improves compatibility while not altering MissionPlanner functionality at all. Second commit changes the functionality where users would need to use .waypoints so that transitioning between the two programs is then seamless.