### PR TITLE
WMS Server URL with query strings and Input Box UI

### DIFF
--- a/ExtLibs/Controls/InputBox.cs
+++ b/ExtLibs/Controls/InputBox.cs
@@ -46,42 +46,58 @@ namespace MissionPlanner.Controls
         static DialogResult ShowUI(string title, string promptText, string value, bool password = false)
         {
             Form form = new Form();
-            System.Windows.Forms.Label label = new System.Windows.Forms.Label();
+            Label label = new Label();
             TextBox textBox = new TextBox();
             if (password)
                 textBox.UseSystemPasswordChar = true;
-            Controls.MyButton buttonOk = new Controls.MyButton();
-            Controls.MyButton buttonCancel = new Controls.MyButton();
+            MyButton buttonOk = new MyButton();
+            MyButton buttonCancel = new MyButton();
             //System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainV2));
             //form.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
 
+            // Suspend form layout.
+            form.SuspendLayout();
+            const int yMargin = 10;
+
+            //
+            // label
+            //
+            var y = 20;
+            label.AutoSize = true;
+            label.Location = new Point(9, y);
+            label.Size = new Size(372, 13);
+            label.Text = promptText;
+            label.MaximumSize = new Size(372, 0);
+
+            //
+            // textBox
+            //
+            textBox.Size = new Size(372, 20);
+            textBox.Text = value;
+            textBox.TextChanged += textBox_TextChanged;
+
+            //
+            // buttonOk
+            //
+            buttonOk.Size = new Size(75, 23);
+            buttonOk.Text = "OK";
+            buttonOk.DialogResult = DialogResult.OK;
+            
+            //
+            // buttonCancel
+            //
+            buttonCancel.Size = new Size(75, 23);
+            buttonCancel.Text = "Cancel";
+            buttonCancel.DialogResult = DialogResult.Cancel;
+            
+            //
+            // form
+            //
             form.TopMost = true;
             form.TopLevel = true;
-
             form.Text = title;
-            label.Text = promptText;
-            textBox.Text = value;
-
-            textBox.TextChanged +=textBox_TextChanged;
-
-            buttonOk.Text = "OK";
-            buttonCancel.Text = "Cancel";
-            buttonOk.DialogResult = DialogResult.OK;
-            buttonCancel.DialogResult = DialogResult.Cancel;
-
-            label.SetBounds(9, 10, 372, 26);
-            textBox.SetBounds(12, 46, 372, 20);
-            buttonOk.SetBounds(228, 72, 75, 23);
-            buttonCancel.SetBounds(309, 72, 75, 23);
-
-            label.AutoSize = true;
-            textBox.Anchor = textBox.Anchor | AnchorStyles.Right;
-            buttonOk.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
-            buttonCancel.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
-
             form.ClientSize = new Size(396, 107);
             form.Controls.AddRange(new Control[] { label, textBox, buttonOk, buttonCancel });
-            form.ClientSize = new Size(Math.Max(300, label.Right + 10), form.ClientSize.Height);
             form.FormBorderStyle = FormBorderStyle.FixedSingle;
             form.StartPosition = FormStartPosition.CenterScreen;
             form.MinimizeBox = false;
@@ -89,10 +105,22 @@ namespace MissionPlanner.Controls
             form.AcceptButton = buttonOk;
             form.CancelButton = buttonCancel;
 
+            // Resume form layout
+            form.ResumeLayout(false);
+            form.PerformLayout();
+
+            // Adjust the location of textBox, buttonOk, buttonCancel based on the content of the label.
+            y = y + label.Height + yMargin;
+            textBox.Location = new Point(12, y);
+            y = y + textBox.Height + yMargin;
+            buttonOk.Location = new Point(228, y);
+            buttonCancel.Location = new Point(309, y);
+            // Increase the size of the form.
+            form.ClientSize = new Size(396, y + buttonOk.Height + yMargin);
+
             if (ApplyTheme != null)
                 ApplyTheme(form);
-
-            DialogResult dialogResult = DialogResult.Cancel;
+            
 
             Console.WriteLine("Input Box " + System.Threading.Thread.CurrentThread.Name);
 
@@ -102,7 +130,7 @@ namespace MissionPlanner.Controls
 
             Console.WriteLine("Input Box 2 " + System.Threading.Thread.CurrentThread.Name);
 
-            dialogResult = form.DialogResult;
+            DialogResult dialogResult = form.DialogResult;
 
             if (dialogResult == DialogResult.OK)
             {

--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -2824,7 +2824,8 @@ namespace MissionPlanner.GCSViews
                 if (DialogResult.Cancel == InputBox.Show("WMS Server", "Enter the WMS server URL", ref url))
                     return;
 
-                string szCapabilityRequest = url + "?version=1.1.0&Request=GetCapabilities&service=WMS";
+                // Build get capability request.
+                string szCapabilityRequest = BuildGetCapabilitityRequest(url);
 
                 XmlDocument xCapabilityResponse = MakeRequest(szCapabilityRequest);
                 ProcessWmsCapabilitesRequest(xCapabilityResponse);
@@ -2832,6 +2833,37 @@ namespace MissionPlanner.GCSViews
                 MainV2.config["WMSserver"] = url;
                 WMSProvider.CustomWMSURL = url;
             }
+        }
+
+        /// <summary>
+        /// Builds the get Capability request.
+        /// </summary>
+        /// <param name="serverUrl">The server URL.</param>
+        /// <returns></returns>
+        private string BuildGetCapabilitityRequest(string serverUrl)
+        {
+            // What happens if the URL already has  '?'. 
+            // For example: http://foo.com?Token=yyyy
+            // In this example, the get capability request should be 
+            // http://foo.com?Token=yyyy&version=1.1.0&Request=GetCapabilities&service=WMS but not
+            // http://foo.com?Token=yyyy?version=1.1.0&Request=GetCapabilities&service=WMS
+
+            // If the URL doesn't contain '?', append it.
+            if (!serverUrl.Contains("?"))
+            {
+                serverUrl += "?";
+            }
+            else
+            {
+                // Check if the URL already has query strings.
+                // If the URL doesn't have query strings, '?' comes at the end.
+                if (!serverUrl.EndsWith("?"))
+                {
+                    // Already have query string, so add '&' before adding other query strings.
+                    serverUrl += "&";
+                }
+            }
+            return serverUrl + "version=1.1.0&Request=GetCapabilities&service=WMS";
         }
 
         /**

--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -2955,20 +2955,44 @@ namespace MissionPlanner.GCSViews
             }
 
 
-            //the server is capable of serving our requests - now check if there is a layer to be selected
-            //format: layer -> layer -> name
+            // the server is capable of serving our requests - now check if there is a layer to be selected
+            // Display layer title in the input box instead of layer name.
+            // format: layer -> layer -> name
+            //         layer -> layer -> title
             string szLayerSelection = "";
             int iSelect = 0;
             List<string> szListLayerName = new List<string>();
-            XmlNodeList layerELements = xCapabilitesResponse.SelectNodes("//Layer/Layer/Name", nsmgr);
-            foreach (XmlNode nameNode in layerELements)
+            // Loop through all layers.
+            XmlNodeList layerElements = xCapabilitesResponse.SelectNodes("//Layer/Layer", nsmgr);
+            foreach (XmlNode layerElement in layerElements)
             {
-                szLayerSelection += string.Format("{0}: " + nameNode.InnerText + ", ", iSelect);
-                    //mixing control and formatting is not optimal...
-                szListLayerName.Add(nameNode.InnerText);
-                iSelect++;
-            }
+                // Get Name element.
+                var nameNode = layerElement.SelectSingleNode("Name", nsmgr);
 
+                // Skip if no name element is found.
+                if (nameNode != null)
+                {
+                    var name = nameNode.InnerText;
+                    // Set the default title as the layer name. 
+                    var title = name;
+                    // Get Title element.
+                    var titleNode = layerElement.SelectSingleNode("Title", nsmgr);
+                    if (titleNode != null)
+                    {
+                        var titleText = titleNode.InnerText;
+                        if (!string.IsNullOrWhiteSpace(titleText))
+                        {
+                            title = titleText;
+                        }
+                    }
+                    szListLayerName.Add(name);
+
+                    szLayerSelection += string.Format("{0}: {1}, ", iSelect, title);
+                    //mixing control and formatting is not optimal...
+                    iSelect++;
+                }
+            }
+            
 
             //only select layer if there is one
             if (szListLayerName.Count != 0)

--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -2987,13 +2987,12 @@ namespace MissionPlanner.GCSViews
                     }
                     szListLayerName.Add(name);
 
-                    szLayerSelection += string.Format("{0}: {1}, ", iSelect, title);
+                    szLayerSelection += string.Format("{0}: {1}\n ", iSelect, title);
                     //mixing control and formatting is not optimal...
                     iSelect++;
                 }
             }
-            
-
+           
             //only select layer if there is one
             if (szListLayerName.Count != 0)
             {
@@ -3001,8 +3000,8 @@ namespace MissionPlanner.GCSViews
                 string szUserSelection = "";
                 if (DialogResult.Cancel ==
                     InputBox.Show("WMS Server",
-                        "The following layers were detected: " + szLayerSelection +
-                        "please choose one by typing the associated number.", ref szUserSelection))
+                        "The following layers were detected:\n " + szLayerSelection +
+                        "Please choose one by typing the associated number.", ref szUserSelection))
                     return;
                 int iUserSelection = 0;
                 try


### PR DESCRIPTION
Added functionality to accept WMS server URL with query strings, Displayed WMS layer title instead of the layer name, Auto-sized an input box displaying the list of WMS layers vertically.

![verticalautosize](https://cloud.githubusercontent.com/assets/3926452/11277587/c1ae8b82-8eac-11e5-8266-65ff46049087.png)
