### PR TITLE
Make waypoints appear on flight data screen on WP read

### DIFF
--- a/Mavlink/MAVLinkInterface.cs
+++ b/Mavlink/MAVLinkInterface.cs
@@ -1796,6 +1796,8 @@ Please check the following
                         log.InfoFormat("getWP {0} {1} {2} {3} {4} opt {5}", loc.id, loc.p1, loc.alt, loc.lat, loc.lng,
                             loc.options);
 
+                        MAV.wps[wp.seq] = wp; 
+
                         break;
                     }
                     else


### PR DESCRIPTION
I ran into problem that waypoints aren't displayed on Flight Data screen when they were read from MAV. They appear only when they are written to MAV. I don't know if this is intentional, but this is quite problem for me when i'm using large missions (~700wp's).