### PR TITLE
GMapMarker: Make Position virtual

### DIFF
--- a/ExtLibs/GMap.NET.WindowsForms/GMap.NET.WindowsForms/GMapMarker.cs
+++ b/ExtLibs/GMap.NET.WindowsForms/GMap.NET.WindowsForms/GMapMarker.cs
@@ -39,7 +39,7 @@ namespace GMap.NET.WindowsForms
       }
 
       private PointLatLng position;
-      public PointLatLng Position
+      public virtual PointLatLng Position
       {
          get
          {


### PR DESCRIPTION
This allows custom positioning logic per marker: for instance a marker type could have it's position set once and not be allowed to move.