### PR TITLE
Reduce build times

### DIFF
--- a/ExtLibs/MetaDataExtractorCSharp240d/MetaDataExtractor.csproj
+++ b/ExtLibs/MetaDataExtractorCSharp240d/MetaDataExtractor.csproj
@@ -95,17 +95,17 @@
     <Compile Include="com\drew\imaging\tiff\TiffMetadataReader.cs" />
     <Compile Include="com\drew\imaging\tiff\TiffProcessingException.cs" />
     <Content Include="exif.xslt">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="sampleFile.xml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <None Include="dontcare.snk" />
     <None Include="MetadataExtractor.dtd">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="MetadataExtractorNew.dtd">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <Compile Include="AssemblyInfo.cs">
       <SubType>Code</SubType>

--- a/ExtLibs/px4uploader/px4uploader.csproj
+++ b/ExtLibs/px4uploader/px4uploader.csproj
@@ -102,7 +102,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="validcertificates.xml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/MissionPlanner.csproj
+++ b/MissionPlanner.csproj
@@ -1530,7 +1530,7 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="airports.csv">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Drivers\amd64\ftd2xx.lib">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -1572,7 +1572,7 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="flightgear.zip">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Lib\site-packages\scipy\fftpack\tests\fftw_double_ref.npz" />
     <None Include="Lib\site-packages\scipy\fftpack\tests\fftw_single_ref.npz" />
@@ -1580,7 +1580,7 @@
     <None Include="Lib\site-packages\scipy\special\tests\data\boost.npz" />
     <None Include="Lib\tabnanny.pyc" />
     <None Include="MissionPlanner.sh">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="NoFly\SouthAfricaNoRPASOutlined.kmz">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -2982,16 +2982,16 @@
     <None Include="Properties\app.manifest" />
     <None Include="Properties\DataSources\CurrentState.datasource" />
     <None Include="block_plane_0.dae">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Resources\Welcome_to_Michael_Oborne.rtf" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="acsimplepids.xml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="aircraft.xml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="aircraft\arducopter\arducopter-set.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -3078,16 +3078,16 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="ArduCopterConfig.xml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="camerasBuiltin.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="ChangeLog.txt">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="checklistDefault.xml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="DLLs\fftpack_lite.dll">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -3183,7 +3183,7 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="mavgraphs.xml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Scripts\example5 inject data.py">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -3259,14 +3259,14 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="FirmwareHistory.txt">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="hud.html">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <SubType>Designer</SubType>
     </Content>
     <Content Include="JSBSim.exe">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="jsbsim\fgout.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -6636,7 +6636,7 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="mavcmd.xml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <SubType>Designer</SubType>
     </Content>
     <None Include="Resources\hardwareconfig.png" />
@@ -6719,7 +6719,7 @@
     <None Include="Resources\maggps.png" />
     <Content Include="mpdesktop.ico" />
     <Content Include="ParameterMetaDataBackup.xml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Resources\APM_rover-firmware.png" />
     <None Include="Resources\frames-h.png" />
@@ -6799,7 +6799,7 @@
       <Generator>ProtoBufTool</Generator>
     </None>
     <None Include="version.exe">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Resources\MinimOSD.jpg" />
     <None Include="Resources\new-3DR-04.png" />
@@ -6841,7 +6841,7 @@
     </None>
     <None Include="Resources\new frames-09.png" />
     <Content Include="dataflashlog.xml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <SubType>Designer</SubType>
     </Content>
     <None Include="Resources\plane2.png" />
@@ -6868,10 +6868,10 @@
     <None Include="Resources\09028-01.jpg" />
     <None Include="Resources\AC-0004-11-2.jpg" />
     <Content Include="MAVLink.xml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="quadhil.xml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <None Include="Resources\APM_airframes-07.png" />
     <None Include="Resources\APM_airframes-08.png" />


### PR DESCRIPTION
Reduce build times by only copying files if newer.  Previously when building `MissionPlanner` both `MetadataExtractor` and `px4uploader` would **always** build.  The added build time is especially noticeable when building plugins since they depend on `MissionPlanner`.  By only copying rarely updated resources if they are newer instead of always we prevent the compilation of `MetadataExtractor` and `px4uploader` unless files have changed.