### PR TITLE
Log: reject large spikes in log files

### DIFF
--- a/Log/LogBrowse.cs
+++ b/Log/LogBrowse.cs
@@ -973,6 +973,7 @@ namespace MissionPlanner.Log
 
             double b = 0;
             DateTime screenupdate = DateTime.MinValue;
+            double value_prev = 0;
 
             foreach (var item in logdata.GetEnumeratorType(type))
             {
@@ -999,6 +1000,13 @@ namespace MissionPlanner.Log
 
                         if (dataModifier.IsValid())
                         {
+                            if ((a != 0) && Math.Abs(value - value_prev) > 1e5)
+                            {
+                                // there is a glitch in the data, reject it by replacing it with the previous value
+                                value = value_prev;
+                            }
+                            value_prev = value;
+
                             if (dataModifier.doOffsetFirst)
                             {
                                 value += dataModifier.offset;


### PR DESCRIPTION
when data has large spikes (1E30) it can make it hard to view certain values. This eliminates those spikes but only if you are processing your data with an offset/scaler. So, to remove then just use " *1 ". This is a hack. @meee1 do you have a better way to show the original data but then also be able to remove glitches without adding work to existing normal logs?