### PR TITLE
Use Assembly.LoadFrom when loading plugins

### DIFF
--- a/Plugin/PluginLoader.cs
+++ b/Plugin/PluginLoader.cs
@@ -24,7 +24,7 @@ namespace MissionPlanner.Plugin
 
             try
             {
-                asm = Assembly.LoadFile(file);
+                asm = Assembly.LoadFrom(file);
             }
             catch (Exception)
             {


### PR DESCRIPTION
Previously we would fail loading plugins if they were dependent on another DLL
in the directory (nuget packages, third-party libraries etc.).  Using LoadFrom
successfully loads those dependent assemblies.